### PR TITLE
fix iteritems to work in both Python 2 and 3

### DIFF
--- a/ibm_db_sa/ibm_db_sa/pyodbc.py
+++ b/ibm_db_sa/ibm_db_sa/pyodbc.py
@@ -18,6 +18,7 @@
 # +--------------------------------------------------------------------------+
 from sqlalchemy import util
 import urllib
+from future.utils import iteritems
 from sqlalchemy.connectors.pyodbc import PyODBCConnector
 from .base import _SelectLastRowIDMixin, DB2ExecutionContext, DB2Dialect
 from . import reflection as ibm_reflection
@@ -84,7 +85,7 @@ class DB2Dialect_pyodbc(PyODBCConnector, DB2Dialect):
                                         keys.pop("odbc_autotranslate"))
 
             connectors.extend(['%s=%s' % (k, v)
-                                    for k, v in keys.iteritems()])
+                                    for k, v in iteritems(keys)])
         return [[";".join(connectors)], connect_args]
 
 class AS400Dialect_pyodbc(PyODBCConnector, DB2Dialect):


### PR DESCRIPTION
.iteritems() was removed from dicts in Python 3. Using the iteritems function from future.utils will allow the code to function in both Python 2 and 3.