### PR TITLE
fix for missing attributes when using pyodbc

### DIFF
--- a/ibm_db_sa/ibm_db_sa/base.py
+++ b/ibm_db_sa/ibm_db_sa/base.py
@@ -693,8 +693,8 @@ class DB2Dialect(default.DefaultDialect):
     # object which selects between DB2 and AS/400 schemas
     def initialize(self, connection):
         super(DB2Dialect, self).initialize(connection)
-        self.dbms_ver = connection.connection.dbms_ver
-        self.dbms_name = connection.connection.dbms_name
+        self.dbms_ver = getattr(connection.connection, 'dbms_ver', None)
+        self.dbms_name = getattr(connection.connection, 'dbms_name', None)
         
     def normalize_name(self, name):
         return self._reflector.normalize_name(name)


### PR DESCRIPTION
These attributes are not available when connecting through pyodbc. Issue #29 