### PR TITLE
Fix for reflection get_primary_keys

### DIFF
--- a/ibm_db_sa/ibm_db_sa/reflection.py
+++ b/ibm_db_sa/ibm_db_sa/reflection.py
@@ -275,15 +275,15 @@ class DB2Reflector(BaseReflector):
     def get_primary_keys(self, connection, table_name, schema=None, **kw):
         current_schema = self.denormalize_name(schema or self.default_schema_name)
         table_name = self.denormalize_name(table_name)
-        sysindexes = self.sys_indexes
+        syscols = self.sys_columns
         col_finder = re.compile("(\w+)")
-        query = sql.select([sysindexes.c.colnames],
+        query = sql.select([syscols.c.colname],
               sql.and_(
-                  sysindexes.c.tabschema == current_schema,
-                  sysindexes.c.tabname == table_name,
-                  sysindexes.c.uniquerule == 'P'
+                  syscols.c.tabschema == current_schema,
+                  syscols.c.tabname == table_name,
+                  syscols.c.keyseq > 0
                 ),
-              order_by=[sysindexes.c.tabschema, sysindexes.c.tabname]
+              order_by=[syscols.c.tabschema, syscols.c.tabname]
             )
         pk_columns = []
         for r in connection.execute(query):

--- a/ibm_db_sa/ibm_db_sa/reflection.py
+++ b/ibm_db_sa/ibm_db_sa/reflection.py
@@ -150,6 +150,8 @@ class DB2Reflector(BaseReflector):
       Column("SCALE", sa_types.Integer, key="scale"),
       Column("DEFAULT", CoerceUnicode, key="defaultval"),
       Column("NULLS", CoerceUnicode, key="nullable"),
+      Column("KEYSEQ", CoerceUnicode, key="keyseq"),
+      Column("PARTKEYSEQ", CoerceUnicode, key="partkeyseq"),
       Column("IDENTITY", CoerceUnicode, key="identity"),
       Column("GENERATED", CoerceUnicode, key="generated"),
       schema="SYSCAT")


### PR DESCRIPTION
Reflection wasn't working on DB2 Warehouse on Cloud, and possibly wasn't working with some other recent DB2 versions, which do not have a valid SYSCOL.INDEXES.COLNAMES
From the documentation:
https://www.ibm.com/support/knowledgecenter/SSEPGG_11.5.0/com.ibm.db2.luw.sql.ref.doc/doc/r0001047.html
> This column is no longer used and will be removed in the next release. Use SYSCAT.INDEXCOLUSE for this information.

Other changes in ibm_db_sa may be necessary due to the same backwards-incompatible change in DB2, for example, in get_indexes, which should return the index columns