### PR TITLE
DB2 may not return the column names in SYSCOL.INDEXES

### DIFF
--- a/ibm_db_sa/ibm_db_sa/reflection.py
+++ b/ibm_db_sa/ibm_db_sa/reflection.py
@@ -275,15 +275,15 @@ class DB2Reflector(BaseReflector):
     def get_primary_keys(self, connection, table_name, schema=None, **kw):
         current_schema = self.denormalize_name(schema or self.default_schema_name)
         table_name = self.denormalize_name(table_name)
-        sysindexes = self.sys_indexes
+        syscols = self.sys_columns
         col_finder = re.compile("(\w+)")
-        query = sql.select([sysindexes.c.colnames],
+        query = sql.select([syscols.c.colname],
               sql.and_(
-                  sysindexes.c.tabschema == current_schema,
-                  sysindexes.c.tabname == table_name,
-                  sysindexes.c.uniquerule == 'P'
+                  syscols.c.tabschema == current_schema,
+                  syscols.c.tabname == table_name,
+                  syscols.c.keyseq > 0
                 ),
-              order_by=[sysindexes.c.tabschema, sysindexes.c.tabname]
+              order_by=[syscols.c.tabschema, syscols.c.tabname]
             )
         pk_columns = []
         for r in connection.execute(query):

--- a/ibm_db_sa/ibm_db_sa/reflection.py
+++ b/ibm_db_sa/ibm_db_sa/reflection.py
@@ -150,6 +150,8 @@ class DB2Reflector(BaseReflector):
       Column("SCALE", sa_types.Integer, key="scale"),
       Column("DEFAULT", CoerceUnicode, key="defaultval"),
       Column("NULLS", CoerceUnicode, key="nullable"),
+      Column("KEYSEQ", CoerceUnicode, key="keyseq"),
+      Column("PARTKEYSEQ", CoerceUnicode, key="partkeyseq"),
       Column("IDENTITY", CoerceUnicode, key="identity"),
       Column("GENERATED", CoerceUnicode, key="generated"),
       schema="SYSCAT")

--- a/ibm_db_sa/ibm_db_sa/reflection.py
+++ b/ibm_db_sa/ibm_db_sa/reflection.py
@@ -392,6 +392,8 @@ class DB2Reflector(BaseReflector):
             if r[2] != 'P':
                 if r[2] == 'U' and r[3] != 0:
                     continue
+                if 'sqlnotapplicable' in r[1].lower():
+                    continue
                 indexes.append({
                         'name': self.normalize_name(r[0]),
                         'column_names': [self.normalize_name(col)


### PR DESCRIPTION
COLNAMES usage is deprecated:
https://www.ibm.com/support/knowledgecenter/SSEPGG_11.5.0/com.ibm.db2.luw.sql.ref.doc/doc/r0001047.html

related to https://github.com/ibmdb/python-ibmdbsa/pull/60