### PR TITLE
Fixed issue with setting isolation level

### DIFF
--- a/ibm_db_sa/ibm_db_sa/ibm_db.py
+++ b/ibm_db_sa/ibm_db_sa/ibm_db.py
@@ -125,7 +125,7 @@ class DB2Dialect_ibm_db(DB2Dialect):
     _isolation_levels_returned = { value : key for key, value in _isolation_levels_cli.items()}
 
     def _get_cli_isolation_levels(self, level):
-        return _isolation_levels_cli[level]
+        return self._isolation_levels_cli[level]
 
     def set_isolation_level(self, connection, level):    
         if level is  None:
@@ -140,7 +140,7 @@ class DB2Dialect_ibm_db(DB2Dialect):
                 "Valid isolation levels for %s are %s" %
                 (level, self.name, ", ".join(self._isolation_lookup))
             )
-        attrib = {SQL_ATTR_TXN_ISOLATION:_get_cli_isolation_levels(self,level)}
+        attrib = {SQL_ATTR_TXN_ISOLATION: self._get_cli_isolation_levels(self,level)}
         res = connection.set_option(attrib)
 
         

--- a/ibm_db_sa/ibm_db_sa/ibm_db.py
+++ b/ibm_db_sa/ibm_db_sa/ibm_db.py
@@ -140,7 +140,7 @@ class DB2Dialect_ibm_db(DB2Dialect):
                 "Valid isolation levels for %s are %s" %
                 (level, self.name, ", ".join(self._isolation_lookup))
             )
-        attrib = {SQL_ATTR_TXN_ISOLATION: self._get_cli_isolation_levels(self,level)}
+        attrib = {SQL_ATTR_TXN_ISOLATION: self._get_cli_isolation_levels(level)}
         res = connection.set_option(attrib)
 
         


### PR DESCRIPTION
Two lines were missing the "self" reference for calling methods on the instanced class. This was causing errors (couldn't find methods) when setting the isolation level via "execution_options" on the connection.