### PR TITLE
Fix urllib import to work with python 3

### DIFF
--- a/ibm_db_sa/ibm_db_sa/pyodbc.py
+++ b/ibm_db_sa/ibm_db_sa/pyodbc.py
@@ -17,7 +17,10 @@
 # | Contributors: Mike Bayer                                                 |
 # +--------------------------------------------------------------------------+
 from sqlalchemy import util
-import urllib
+try:
+    import urllib.parse as urllib
+except ImportError:
+    import urllib
 from sqlalchemy.connectors.pyodbc import PyODBCConnector
 from .base import _SelectLastRowIDMixin, DB2ExecutionContext, DB2Dialect
 from . import reflection as ibm_reflection


### PR DESCRIPTION
Added try/except to import urllib.parse for python 3.