### PR TITLE
Isolation level fix

### DIFF
--- a/ibm_db_sa/CHANGES
+++ b/ibm_db_sa/CHANGES
@@ -1,5 +1,8 @@
 CHANGES
 =======
+2020/04/17
+- Fixed NameError: name '_get_cli_isolation_levels' is not defined
+
 2019/05/30
 - Added fix for missing "CURRENT ISOLATION" register
 - Fixed Autocommit not working for pyodbc

--- a/ibm_db_sa/ibm_db_sa/ibm_db.py
+++ b/ibm_db_sa/ibm_db_sa/ibm_db.py
@@ -125,7 +125,7 @@ class DB2Dialect_ibm_db(DB2Dialect):
     _isolation_levels_returned = { value : key for key, value in _isolation_levels_cli.items()}
 
     def _get_cli_isolation_levels(self, level):
-        return _isolation_levels_cli[level]
+        return self._isolation_levels_cli[level]
 
     def set_isolation_level(self, connection, level):    
         if level is  None:
@@ -140,7 +140,7 @@ class DB2Dialect_ibm_db(DB2Dialect):
                 "Valid isolation levels for %s are %s" %
                 (level, self.name, ", ".join(self._isolation_lookup))
             )
-        attrib = {SQL_ATTR_TXN_ISOLATION:_get_cli_isolation_levels(self,level)}
+        attrib = {SQL_ATTR_TXN_ISOLATION: self._get_cli_isolation_levels(level)}
         res = connection.set_option(attrib)
 
         

--- a/ibm_db_sa/ibm_db_sa/ibm_db.py
+++ b/ibm_db_sa/ibm_db_sa/ibm_db.py
@@ -133,7 +133,7 @@ class DB2Dialect_ibm_db(DB2Dialect):
         else :
           if len(level.strip()) < 1:
             level ='CS'
-        level.upper().replace("-", " ")   
+        level = level.upper().replace("-", " ").replace("_", " ")
         if level not in self._isolation_lookup:
             raise ArgumentError(
                 "Invalid value '%s' for isolation_level. "


### PR DESCRIPTION
`self.` was missing in `set_isolation_level` and `_get_cli_isolation_levels` which caused an error calling these methods and made it impossible to set the isolation level.