### PR TITLE
Avoid URL object mutation

### DIFF
--- a/ibm_db_sa/ibm_db.py
+++ b/ibm_db_sa/ibm_db.py
@@ -197,7 +197,7 @@ class DB2Dialect_ibm_db(DB2Dialect):
                     if query_key.lower() == key.lower():
                         dsn_param.append(
                             '%(connection_key)s=%(value)s' % {'connection_key': key, 'value': url.query[query_key]})
-                        del url.query[query_key]
+                        url = url.difference_update_query([query_key])
                         break
 
             dsn = ';'.join(dsn_param)


### PR DESCRIPTION
Since SQLAlchemy 1.4, [`URL` objects have been immutable](https://docs.sqlalchemy.org/en/14/changelog/migration_14.html#the-url-object-is-now-immutable). 

This causes line 200 below to fail, for example if a `URL` is provided with:<br/>`query = {"Security": "SSL", "SSLServerCertificate": "/path/to/certificate.crt"}`

https://github.com/ibmdb/python-ibmdbsa/blob/009d89bcda64c5390b6067c639ac0b8b8c17ea6c/ibm_db_sa/ibm_db.py#L191-L201

> ```
> Traceback (most recent call last):
>   File "<stdin>", line 1, in <module>
>   File "<string>", line 2, in create_engine
>   File "/Users/eonu/env/test/lib/python3.8/site-packages/sqlalchemy/util/deprecations.py", line 309, in warned
>     return fn(*args, **kwargs)
>   File "/Users/eonu/env/test/lib/python3.8/site-packages/sqlalchemy/engine/create.py", line 576, in create_engine
>     (cargs, cparams) = dialect.create_connect_args(u)
>   File "/Users/eonu/env/test/lib/python3.8/site-packages/ibm_db_sa/ibm_db.py", line 200, in create_connect_args
>     del url.query[query_key]
> TypeError: 'sqlalchemy.cimmutabledict.immutabledict' object does not support item deletion
> ```

Using [`URL.difference_update_query`](https://github.com/zzzeek/sqlalchemy/blob/366a5e3e2e503a20ef0334fbf9f94c7e421008fa/lib/sqlalchemy/engine/url.py#L519-L522) is the correct way to remove keys from the query and return an updated `URL`.