### PR TITLE
Update pyodbc.py

### DIFF
--- a/ibm_db_sa/pyodbc.py
+++ b/ibm_db_sa/pyodbc.py
@@ -30,6 +30,7 @@ class DB2Dialect_pyodbc(PyODBCConnector, DB2Dialect):
     supports_unicode_statements = True
     supports_char_length = True
     supports_native_decimal = False
+    supports_statement_cache = False
 
     execution_ctx_cls = DB2ExecutionContext_pyodbc
 


### PR DESCRIPTION
When executing select queries using the ibm_db_sa:pyodbc dialect, a warning displays in the console.

Adding the supports_statement_cache property will silence this warning. Alternatively if caching is supported, this property can be changed to True. Eitherway from SQLAlchemy 1.4 this property is required.

Silences the following console output
> SAWarning: Dialect ibm_db_sa:pyodbc will not make use of SQL compilation caching as it does not set the 'supports_statement_cache' attribute to ``True``.