### PR TITLE
Resolved Boolean renders as smallint

### DIFF
--- a/ibm_db_sa/base.py
+++ b/ibm_db_sa/base.py
@@ -239,6 +239,9 @@ class DB2TypeCompiler(compiler.GenericTypeCompiler):
     def visit_SMALLINT(self, type_, **kw):
         return "SMALLINT"
 
+    def visit_BOOLEAN(self, type_, **kw):
+        return "BOOLEAN"
+
     def visit_INT(self, type_, **kw):
         return "INT"
 
@@ -311,7 +314,7 @@ class DB2TypeCompiler(compiler.GenericTypeCompiler):
         return self.visit_INT(type_, **kw)
 
     def visit_boolean(self, type_, **kw):
-        return self.visit_SMALLINT(type_, **kw)
+        return self.visit_BOOLEAN(type_, **kw)
 
     def visit_float(self, type_, **kw):
         return self.visit_FLOAT(type_, **kw)


### PR DESCRIPTION
This PR addresses https://github.com/ibmdb/python-ibmdbsa/issues/161.

Now updated Boolean will renders as BOOLEAN.

```
import sqlalchemy as sa

url = "db2+ibm_db://db2inst1:password@localhost:50000/testdb"

engine = sa.create_engine(url)
print(sa.Boolean().compile(engine.dialect))
```
prints BOOLEAN