### PR TITLE
Enable supports_statement_cache for Db2 SQLAlchemy dialects

### DIFF
--- a/ibm_db_sa/ibm_db.py
+++ b/ibm_db_sa/ibm_db.py
@@ -99,7 +99,7 @@ class DB2ExecutionContext_ibm_db(DB2ExecutionContext):
 class DB2Dialect_ibm_db(DB2Dialect):
     driver = 'ibm_db_sa'
     supports_unicode_statements = True
-    supports_statement_cache = False
+    supports_statement_cache = True
     supports_sane_rowcount = True
     supports_sane_multi_rowcount = False
     supports_native_decimal = False

--- a/ibm_db_sa/pyodbc.py
+++ b/ibm_db_sa/pyodbc.py
@@ -30,7 +30,7 @@ class DB2Dialect_pyodbc(PyODBCConnector, DB2Dialect):
     supports_unicode_statements = True
     supports_char_length = True
     supports_native_decimal = False
-    supports_statement_cache = False
+    supports_statement_cache = True
 
     execution_ctx_cls = DB2ExecutionContext_pyodbc
 

--- a/ibm_db_sa/reflection.py
+++ b/ibm_db_sa/reflection.py
@@ -29,6 +29,7 @@ from sys import version_info
 
 class CoerceUnicode(sa_types.TypeDecorator):
     impl = sa_types.Unicode
+    cache_ok = True
 
     def process_bind_param(self, value, dialect):
         if isinstance(value, str):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=42", "wheel"]
+requires = ["setuptools>=42", "wheel", "packaging>=20.0"]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -11,9 +11,9 @@ v.close()
 
 readme = os.path.join(os.path.dirname(__file__), 'README.md')
 if 'USE_PYODBC' in os.environ and os.environ['USE_PYODBC'] == '1':
-    require = ['sqlalchemy>=0.7.3']
+    require = ['sqlalchemy>=0.7.3', 'packaging>=20.0']
 else:
-    require = ['sqlalchemy>=0.7.3','ibm_db>=2.0.0']
+    require = ['sqlalchemy>=0.7.3','ibm_db>=2.0.0', 'packaging>=20.0']
     
 
 setup(


### PR DESCRIPTION
This PR addresses issue https://github.com/ibmdb/python-ibmdbsa/issues/187 and enables **SQLAlchemy statement cache support** for the Db2 SQLAlchemy dialect (`ibm_db_sa`).
The change refactors LIMIT / OFFSET SQL compilation to ensure that:
- Compiled SQL strings are **stable and reusable**
- Bind parameters and post-compile parameters are preserved
- SQL text is **not dependent on runtime values**
- OFFSET-only queries are safely rewritten using `ROW_NUMBER()` while remaining cache-friendly
As a result, the dialect can safely advertise:
```python
supports_statement_cache = True
```


For more info related to it, please go through below documentation links of SQLAlchemy

- Dialect caching support: https://docs.sqlalchemy.org/en/20/core/internals.html#sqlalchemy.engine.Dialect.supports_statement_cache

- Caching requirements for third-party dialects: https://docs.sqlalchemy.org/en/20/core/connections.html#engine-thirdparty-caching