### PR TITLE
Fix #196: CLI0109E String data right truncation in has_table() with pd.read_sql()

### DIFF
--- a/ibm_db_sa/base.py
+++ b/ibm_db_sa/base.py
@@ -1475,6 +1475,13 @@ class DB2Dialect(default.DefaultDialect):
 
     @log_entry_exit
     def has_table(self, connection, table_name, schema=None, **kw):
+        if not isinstance(table_name, str) or len(table_name) > 128:
+            logger.debug(
+                f"has_table -> returning False (invalid table_name: "
+                f"type={type(table_name).__name__}, "
+                f"len={len(table_name) if isinstance(table_name, str) else 'N/A'})"
+            )
+            return False
         exists = self._reflector.has_table(connection, table_name, schema=schema, **kw)
         logger.debug(f"Table exists -> {exists}")
         return exists

--- a/ibm_db_sa/reflection.py
+++ b/ibm_db_sa/reflection.py
@@ -243,6 +243,8 @@ class DB2Reflector(BaseReflector):
     @log_entry_exit
     def has_table(self, connection, table_name, schema=None, **kw):
         try:
+            if not isinstance(table_name, str) or len(table_name) > 128:
+                return False
             logger.debug(f"Checking table existence -> schema={schema}, table={table_name}")
             current_schema = self.denormalize_name(schema or self.default_schema_name)
             original_table_name = table_name
@@ -903,6 +905,8 @@ class AS400Reflector(BaseReflector):
     @log_entry_exit
     def has_table(self, connection, table_name, schema=None, **kw):
         try:
+            if not isinstance(table_name, str) or len(table_name) > 128:
+                return False
             current_schema = self.denormalize_name(schema or self.default_schema_name)
             table_name = self.denormalize_name(table_name)
             logger.debug(
@@ -1503,6 +1507,8 @@ class OS390Reflector(BaseReflector):
     @log_entry_exit
     def has_table(self, connection, table_name, schema=None, **kw):
         try:
+            if not isinstance(table_name, str) or len(table_name) > 128:
+                return False
             current_schema = self.denormalize_name(schema or self.default_schema_name)
             table_name = self.denormalize_name(table_name)
             logger.debug(


### PR DESCRIPTION
**Problem**
When using `pd.read_sql(sql=query, con=conn)` with SQLAlchemy 2.0.47+,
pandas internally calls `dialect.has_table()` passing the entire SQL query
string as the `table_name` parameter. Since the SQL string exceeds the
maximum Db2 identifier length (128 bytes), the CLI driver raises:
`CLI0109E String data right truncation. SQLSTATE=22001`

Additionally, when `pd.read_sql(sql=text(query), con=conn)` is used,
a `TextClause` object is passed as `table_name`, causing:
`AttributeError: 'TextClause' object has no attribute 'startswith'`

**Root Cause**
`has_table()` did not validate the `table_name` input before querying
SYSCAT.TABLES. Any non-string or oversized input was passed directly
to the database, causing the CLI driver to fail on parameter binding.

**Fix**
Added input validation guard in `has_table()` across all reflectors
(DB2Reflector, AS400Reflector, OS390Reflector) and the dialect entry
point (DB2Dialect). If `table_name` is not a string or exceeds 128
characters (max Db2 table name length on all platforms), return `False`
immediately without querying the database.


Fixes #196 